### PR TITLE
refactor - rename fire function in useMitter composable to emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Fire an event with the composable `useMitter`
 ```vue
 <!--SayHello.vue-->
 <script setup lang="ts">
-  const { fire } = useMitter()
+  const { emit } = useMitter()
   const onClick = () => {
-    fire('hello', 'Hello 🫠🖖')
+    emit('hello', 'Hello 🫠🖖')
   }
 </script>
 
@@ -104,7 +104,7 @@ listen('hello', e => alert(e))
 ## Types
 
 ```typescript
-export type FireFunction = <K extends keyof MitterEvents>(event: K, payload?: MitterEvents[K]) => void
+export type EmitFunction = <K extends keyof MitterEvents>(event: K, payload?: MitterEvents[K]) => void
 
 export type EventHandlerFunction = <K extends keyof MitterEvents>(
   event: K,
@@ -122,7 +122,7 @@ export interface UseMitterReturn {
    * @param event The event name to emit.
    * @param payload Optional payload for the event.
    */
-  fire: FireFunction
+  emit: EmitFunction
 
   /**
    * Registers an event handler.

--- a/playground/components/DecrementButton.vue
+++ b/playground/components/DecrementButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-const { fire, listen } = useMitter()
+const { emit, listen } = useMitter()
 const handle = () => {
-  fire('decrement')
+  emit('decrement')
   listen('hello', e => console.log(e))
 }
 </script>

--- a/playground/components/IncrementButton.vue
+++ b/playground/components/IncrementButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-const { fire } = useMitter()
+const { emit } = useMitter()
 const handle = () => {
-  fire('increment')
+  emit('increment')
 }
 </script>
 

--- a/playground/components/SayHello.vue
+++ b/playground/components/SayHello.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-const { fire } = useMitter()
+const { emit } = useMitter()
 const handle = () => {
-  fire('hello', 'Hello 🫠🖖')
+  emit('hello', 'Hello 🫠🖖')
 }
 </script>
 

--- a/src/runtime/composables/useMitter.ts
+++ b/src/runtime/composables/useMitter.ts
@@ -13,7 +13,7 @@ export const useMitter = () => {
    * @param event The event name to emit.
    * @param payload Optional payload for the event.
    */
-  const fire = <K extends keyof MitterEvents>(event: K, payload?: MitterEvents[K]) => {
+  const emit = <K extends keyof MitterEvents>(event: K, payload?: MitterEvents[K]) => {
     mitter.emit(event, payload!)
   }
   /**
@@ -48,5 +48,5 @@ export const useMitter = () => {
     onUnmounted(() => off(event, handler))
   }
 
-  return { fire, on, off, listen }
+  return { emit, on, off, listen }
 }

--- a/src/utils/moduleMessenger.ts
+++ b/src/utils/moduleMessenger.ts
@@ -22,7 +22,7 @@ export const moduleMessenger: ModuleMessenger = (type, projectTypesPath) => {
       logger.error(`no such file found for event types under path: ${projectTypesPath!}`)
       logger.warn(`Module is working but events not typed - not recommanded`)
       logger.info(`Please provide mittEvents.d.ts file like:`)
-      logger.box(`export type MittEvents = {
+      logger.box(`export type MitterEvents = {
   //Your types
   foo: string
   bar?: number


### PR DESCRIPTION
refactor - rename fire function in useMitter composable to emit for better adoption for people already used to the original package